### PR TITLE
service: server

### DIFF
--- a/server/find_request.go
+++ b/server/find_request.go
@@ -1,0 +1,108 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"github.com/sacloud/packages-go/validate"
+	v1 "github.com/sacloud/phy-api-go/apis/v1"
+)
+
+type FindRequest struct {
+	// 電源状態
+	// キャッシュされた電源状態で絞りこむ
+	PowerStatus string `validate:"omitempty,oneof=on off"`
+
+	// インターネット接続状態の絞り込み
+	//
+	// * common - 共用グローバルネットワークを利用
+	// * void - インターネット接続なし
+	// * {dedicated_subnet_id} - 指定した専用グローバルネットワークを利用
+	Internet string `validate:"omitempty"`
+
+	// ローカルネットワークの接続状態の絞り込み
+	// このパラメーターが複数ある場合は全てのネットワークに接続済み(AND)が対象
+	//
+	// * void - ローカル接続なし
+	// * {private_network_id} - 指定したローカルネットワークを利用
+	PrivateNetworks []string `validate:"omitempty,unique,max=5,required"`
+
+	// タグ検索
+	// このクエリーパラメーターを複数指定した場合は **すべてのタグを設定済み(AND)** のものにマッチ
+	Tags []string `validate:"omitempty,unique,max=10,dive,required"`
+
+	// フリーワード検索
+	// 下記項目の **いずれか** にマッチしたものを抽出する
+	//
+	// * 名前(部分一致)
+	// * 説明(部分一致)
+	// * タグ(部分一致)
+	//
+	// このクエリーパラメーターを複数指定した場合は **複数の語句すべてを含む(AND)** ものにマッチ
+	FreeWords []string `validate:"omitempty,unique,max=5,dive,required"`
+
+	// 取得数
+	Limit int `validate:"omitempty,min=0"`
+
+	// 取得開始位置
+	Offset int `validate:"omitempty,min=0"`
+
+	// 並び順指定, - から始まる場合は降順指定
+	//
+	// * `activated` - 利用開始日順
+	// * `nickname` - 名称順
+	Ordering string `validate:"omitempty,oneof=activated -activated nickname -nickname power_status_stored -power_status_stored"`
+
+	// 付加的情報の取得範囲
+	IncludeFields *IncludeFields
+}
+
+func (req *FindRequest) Validate() error {
+	return validate.New().Struct(req)
+}
+
+func (req *FindRequest) ToRequestParameter() *v1.ListServersParams {
+	params := &v1.ListServersParams{}
+	if req.PowerStatus != "" {
+		powerStatus := v1.ListServersParamsPowerStatus(req.PowerStatus)
+		params.PowerStatus = &powerStatus
+	}
+	if req.Internet != "" {
+		params.Internet = &req.Internet
+	}
+	if len(req.PrivateNetworks) > 0 {
+		params.PrivateNetwork = &req.PrivateNetworks
+	}
+	if len(req.Tags) > 0 {
+		tags := v1.TagFilter(req.Tags)
+		params.Tag = &tags
+	}
+	if len(req.FreeWords) > 0 {
+		words := v1.FreeWordFilter(req.FreeWords)
+		params.FreeWord = &words
+	}
+	if req.Limit > 0 {
+		limit := v1.Limit(req.Limit)
+		params.Limit = &limit
+	}
+	if req.Offset > 0 {
+		offset := v1.Offset(req.Offset)
+		params.Offset = &offset
+	}
+	if req.Ordering != "" {
+		order := v1.ListServersParamsOrdering(req.Ordering)
+		params.Ordering = &order
+	}
+	return params
+}

--- a/server/find_service.go
+++ b/server/find_service.go
@@ -1,0 +1,50 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/sacloud/phy-api-go"
+)
+
+func (s *Service) Find(req *FindRequest) ([]*Server, error) {
+	return s.FindWithContext(context.Background(), req)
+}
+
+func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*Server, error) {
+	if req == nil {
+		req = &FindRequest{}
+	}
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	client := phy.NewServerOp(s.client)
+	found, err := client.List(ctx, req.ToRequestParameter())
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*Server
+	for _, server := range found.Servers {
+		sv := &Server{Server: server}
+		if err := s.fetchAdditionalInfo(ctx, sv, req.IncludeFields); err != nil {
+			return nil, err
+		}
+		results = append(results, sv)
+	}
+	return results, nil
+}

--- a/server/install_request.go
+++ b/server/install_request.go
@@ -1,0 +1,51 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"github.com/sacloud/packages-go/validate"
+	v1 "github.com/sacloud/phy-api-go/apis/v1"
+)
+
+type InstallRequest struct {
+	Id string `service:"-" validate:"required"`
+
+	//インストールするOSイメージ
+	OsImageId string `validate:"required"`
+
+	// パスワード
+	//
+	// Note: 入力規則をprintasciiにしているが、本来の制限は以下の通り。
+	// [0-9a-zA-Z!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~]+
+	// 実装を容易にするために簡易的なバリデーションのみとしている。
+	Password string `validate:"required,min=8,max=32,printascii"`
+
+	// 手動パーティション指定
+	//
+	// リモートコンソールを利用し手動パーティション指定を行うか(OSが対応している場合のみ)
+	ManualPartition bool
+}
+
+func (req *InstallRequest) Validate() error {
+	return validate.New().Struct(req)
+}
+
+func (req *InstallRequest) ToRequestParameter() v1.OsInstallParameter {
+	return v1.OsInstallParameter{
+		ManualPartition: req.ManualPartition,
+		OsImageId:       req.OsImageId,
+		Password:        v1.PasswordInput(req.Password),
+	}
+}

--- a/server/install_service.go
+++ b/server/install_service.go
@@ -1,0 +1,34 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/sacloud/phy-api-go"
+	v1 "github.com/sacloud/phy-api-go/apis/v1"
+)
+
+func (s *Service) Install(req *InstallRequest) error {
+	return s.InstallWithContext(context.Background(), req)
+}
+
+func (s *Service) InstallWithContext(ctx context.Context, req *InstallRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+	client := phy.NewServerOp(s.client)
+	return client.OSInstall(ctx, v1.ServerId(req.Id), req.ToRequestParameter())
+}

--- a/server/power_request.go
+++ b/server/power_request.go
@@ -1,0 +1,41 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"time"
+
+	"github.com/sacloud/packages-go/validate"
+)
+
+type PowerRequest struct {
+	Id string `service:"-" validate:"required"`
+
+	// 電源操作内容
+	Operation string `validate:"required,oneof=on soft reset off"`
+
+	// 電源操作後に希望の状態になるまで待つか
+	NoWait bool
+
+	// 待ち処理のタイムアウト
+	Timeout time.Duration `validate:"omitempty,min=0"`
+
+	// 待ち処理の処理間隔
+	Interval time.Duration `validate:"omitempty,min=0"`
+}
+
+func (req *PowerRequest) Validate() error {
+	return validate.New().Struct(req)
+}

--- a/server/power_service.go
+++ b/server/power_service.go
@@ -1,0 +1,72 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/packages-go/wait"
+	"github.com/sacloud/phy-api-go"
+	v1 "github.com/sacloud/phy-api-go/apis/v1"
+)
+
+func (s *Service) Power(req *PowerRequest) error {
+	return s.PowerWithContext(context.Background(), req)
+}
+
+func (s *Service) PowerWithContext(ctx context.Context, req *PowerRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+	client := phy.NewServerOp(s.client)
+	if err := client.PowerControl(ctx, v1.ServerId(req.Id), v1.ServerPowerOperations(req.Operation)); err != nil {
+		return err
+	}
+
+	if req.NoWait {
+		return nil
+	}
+	return s.waitAfterPowerControl(ctx, req, client)
+}
+
+func (s *Service) waitAfterPowerControl(ctx context.Context, req *PowerRequest, client phy.ServerAPI) error {
+	desiredPowerState := v1.ServerPowerStatusStatusOn
+	switch req.Operation {
+	case "on", "reset":
+		desiredPowerState = v1.ServerPowerStatusStatusOn
+	case "soft", "off":
+		desiredPowerState = v1.ServerPowerStatusStatusOff
+	default:
+		panic(fmt.Sprintf("unexpected power operation: %s", req.Operation))
+	}
+
+	waiter := wait.PollingWaiter{
+		ReadFunc: func() (interface{}, error) {
+			return client.ReadPowerStatus(ctx, v1.ServerId(req.Id))
+		},
+		StateCheckFunc: func(target interface{}) (bool, error) {
+			if state, ok := target.(*v1.ServerPowerStatus); ok {
+				return state.Status == desiredPowerState, nil
+			}
+			return false, nil
+		},
+		Timeout:  req.Timeout,
+		Interval: req.Interval,
+	}
+
+	_, err := waiter.WaitForState(ctx)
+	return err
+}

--- a/server/power_service_test.go
+++ b/server/power_service_test.go
@@ -1,0 +1,57 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	client "github.com/sacloud/api-client-go"
+	"github.com/sacloud/phy-api-go"
+	service "github.com/sacloud/phy-service-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_Power(t *testing.T) {
+	fakeServer := initFakeServer()
+	apiClient := &phy.Client{
+		APIRootURL: fakeServer.URL,
+		Options: &client.Options{
+			UserAgent: service.UserAgent,
+		},
+	}
+	svc := New(apiClient)
+
+	cases := []struct {
+		operation string
+	}{
+		{operation: "soft"},
+		{operation: "on"},
+		{operation: "reset"},
+		{operation: "off"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.operation, func(t *testing.T) {
+			require.NoError(t, svc.Power(&PowerRequest{
+				Id:        serverId,
+				Operation: tc.operation,
+
+				Timeout:  time.Second,
+				Interval: time.Millisecond,
+			}))
+		})
+	}
+}

--- a/server/read_request.go
+++ b/server/read_request.go
@@ -1,0 +1,30 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"github.com/sacloud/packages-go/validate"
+)
+
+type ReadRequest struct {
+	Id string `service:"-" validate:"required"`
+
+	// 付加的情報の取得範囲
+	IncludeFields *IncludeFields
+}
+
+func (req *ReadRequest) Validate() error {
+	return validate.New().Struct(req)
+}

--- a/server/read_service.go
+++ b/server/read_service.go
@@ -1,0 +1,42 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/sacloud/phy-api-go"
+	v1 "github.com/sacloud/phy-api-go/apis/v1"
+)
+
+func (s *Service) Read(req *ReadRequest) (*Server, error) {
+	return s.ReadWithContext(context.Background(), req)
+}
+
+func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*Server, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	client := phy.NewServerOp(s.client)
+	read, err := client.Read(ctx, v1.ServerId(req.Id))
+	if err != nil {
+		return nil, err
+	}
+	sv := &Server{Server: *read}
+	if err := s.fetchAdditionalInfo(ctx, sv, req.IncludeFields); err != nil {
+		return nil, err
+	}
+	return sv, nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,73 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/sacloud/phy-api-go"
+	v1 "github.com/sacloud/phy-api-go/apis/v1"
+)
+
+type Server struct {
+	v1.Server
+	*v1.RaidStatus
+	*v1.ServerPowerStatus
+	OsImages []*v1.OsImage
+}
+
+type IncludeFields struct {
+	// RAID状態(キャッシュ)を含むか
+	//
+	// RefreshedRaidStatusがtrueの場合はそちらが優先される
+	CachedRaidStatus bool
+	// RAID状態(最新)を含むか
+	RefreshedRaidStatus bool
+
+	// 電源状態を含むか
+	PowerStatus bool
+	// インストール可能OS一覧情報を含むか
+	OSImages bool
+}
+
+func (s *Service) fetchAdditionalInfo(ctx context.Context, server *Server, fields *IncludeFields) error {
+	if fields == nil {
+		return nil
+	}
+
+	client := phy.NewServerOp(s.client)
+	if fields.CachedRaidStatus || fields.RefreshedRaidStatus {
+		status, err := client.ReadRAIDStatus(ctx, v1.ServerId(server.ServerId), fields.RefreshedRaidStatus)
+		if err != nil {
+			return err
+		}
+		server.RaidStatus = status
+	}
+	if fields.PowerStatus {
+		status, err := client.ReadPowerStatus(ctx, v1.ServerId(server.ServerId))
+		if err != nil {
+			return err
+		}
+		server.ServerPowerStatus = status
+	}
+	if fields.OSImages {
+		images, err := client.ListOSImages(ctx, v1.ServerId(server.ServerId))
+		if err != nil {
+			return err
+		}
+		server.OsImages = images
+	}
+	return nil
+}

--- a/server/service.go
+++ b/server/service.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import "github.com/sacloud/phy-api-go"
+
+// Service provides a high-level API of for Service
+type Service struct {
+	client *phy.Client
+}
+
+// New returns new service instance of Service
+func New(client *phy.Client) *Service {
+	return &Service{client: client}
+}

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -1,0 +1,248 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	client "github.com/sacloud/api-client-go"
+	"github.com/sacloud/phy-api-go"
+	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/phy-api-go/fake"
+	"github.com/sacloud/phy-api-go/fake/server"
+	service "github.com/sacloud/phy-service-go"
+	"github.com/stretchr/testify/require"
+)
+
+var serverId = "100000000001"
+
+func TestAccount_CRUD_plus_L(t *testing.T) {
+	fakeServer := initFakeServer()
+	apiClient := &phy.Client{
+		APIRootURL: fakeServer.URL,
+		Options: &client.Options{
+			UserAgent: service.UserAgent,
+		},
+	}
+	svc := New(apiClient)
+	var data *Server
+	var dataWithAdditionalFields *Server
+
+	t.Run("read without additional fields", func(t *testing.T) {
+		read, err := svc.Read(&ReadRequest{
+			Id: serverId,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, read)
+
+		require.Nil(t, read.RaidStatus)
+		require.Nil(t, read.ServerPowerStatus)
+		require.Empty(t, read.OsImages)
+
+		data = read
+	})
+
+	t.Run("read with additional fields", func(t *testing.T) {
+		read, err := svc.Read(&ReadRequest{
+			Id: serverId,
+			IncludeFields: &IncludeFields{
+				CachedRaidStatus:    true,
+				RefreshedRaidStatus: true,
+				PowerStatus:         true,
+				OSImages:            true,
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, read)
+
+		require.NotNil(t, read.RaidStatus)
+		require.NotNil(t, read.ServerPowerStatus)
+		require.NotEmpty(t, read.OsImages)
+		dataWithAdditionalFields = read
+	})
+
+	t.Run("read return NotFoundError when account is not found", func(t *testing.T) {
+		id := "not-exists-account-id"
+		read, err := svc.Read(&ReadRequest{
+			Id: id,
+		})
+		require.Nil(t, read)
+		require.Error(t, err)
+		require.True(t, v1.IsError404(err))
+	})
+
+	t.Run("list without additional fields", func(t *testing.T) {
+		found, err := svc.Find(&FindRequest{})
+		require.NoError(t, err)
+		require.Len(t, found, 1)
+
+		require.Equal(t, data, found[0])
+
+		require.Nil(t, found[0].RaidStatus)
+		require.Nil(t, found[0].ServerPowerStatus)
+		require.Empty(t, found[0].OsImages)
+	})
+
+	t.Run("list with additional fields", func(t *testing.T) {
+		found, err := svc.Find(&FindRequest{
+			IncludeFields: &IncludeFields{
+				CachedRaidStatus:    true,
+				RefreshedRaidStatus: true,
+				PowerStatus:         true,
+				OSImages:            true,
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, found, 1)
+
+		require.Equal(t, dataWithAdditionalFields, found[0])
+
+		require.NotNil(t, found[0].RaidStatus)
+		require.NotNil(t, found[0].ServerPowerStatus)
+		require.NotEmpty(t, found[0].OsImages)
+	})
+}
+
+func initFakeServer() *httptest.Server {
+	raidOverallStatus := v1.RaidStatusOverallStatusOk
+	fakeServer := &server.Server{
+		Engine: &fake.Engine{
+			Servers: []*fake.Server{
+				{
+					Server: &v1.Server{
+						CachedPowerStatus: &v1.CachedPowerStatus{
+							Status: v1.CachedPowerStatusStatusOn,
+							Stored: time.Now(),
+						},
+						Ipv4: &v1.ServerIpv4Global{
+							GatewayAddress: "192.0.2.1",
+							IpAddress:      "192.0.2.11",
+							NameServers:    []string{"198.51.100.1", "198.51.100.2"},
+							NetworkAddress: "192.0.2.0",
+							PrefixLength:   24,
+							Type:           v1.ServerIpv4GlobalTypeCommonIpAddress,
+						},
+						LockStatus: nil,
+						PortChannels: []v1.PortChannel{
+							{
+								BondingType:   v1.BondingTypeLacp,
+								LinkSpeedType: v1.PortChannelLinkSpeedTypeN1gbe,
+								Locked:        false,
+								PortChannelId: 1001,
+								Ports:         []int{2001},
+							},
+						},
+						Ports: []v1.InterfacePort{
+							{
+								Enabled:             true,
+								GlobalBandwidthMbps: nil,
+								Internet:            nil,
+								LocalBandwidthMbps:  nil,
+								Mode:                nil,
+								Nickname:            "server01-port01",
+								PortChannelId:       1001,
+								PortId:              2001,
+								PrivateNetworks:     nil,
+							},
+						},
+						ServerId: serverId,
+						Service: v1.ServiceQuiet{
+							Activated:   time.Now(),
+							Description: nil,
+							Nickname:    "server01",
+							ServiceId:   serverId,
+							Tags:        nil,
+						},
+						Spec: v1.ServerSpec{
+							CpuClockSpeed:         3,
+							CpuCoreCount:          4,
+							CpuCount:              1,
+							CpuModelName:          "E3-1220 v6",
+							MemorySize:            8,
+							PortChannel10gbeCount: 0,
+							PortChannel1gbeCount:  1,
+							Storages: []v1.Storage{
+								{
+									BusType:     v1.StorageBusTypeSata,
+									DeviceCount: 2,
+									MediaType:   v1.StorageMediaTypeSsd,
+									Size:        1000,
+								},
+							},
+							TotalStorageDeviceCount: 1,
+						},
+						Zone: v1.Zone{
+							Region: "is",
+							ZoneId: 302,
+						},
+					},
+					RaidStatus: &v1.RaidStatus{
+						LogicalVolumes: []v1.RaidLogicalVolume{
+							{
+								PhysicalDeviceIds: []string{"0", "1"},
+								RaidLevel:         "1",
+								Status:            v1.RaidLogicalVolumeStatusOk,
+								VolumeId:          "0",
+							},
+						},
+						Monitored:     time.Now(),
+						OverallStatus: &raidOverallStatus,
+						PhysicalDevices: []v1.RaidPhysicalDevice{
+							{
+								DeviceId: "0",
+								Slot:     0,
+								Status:   v1.RaidPhysicalDeviceStatusOk,
+							},
+							{
+								DeviceId: "1",
+								Slot:     1,
+								Status:   v1.RaidPhysicalDeviceStatusOk,
+							},
+						},
+					},
+					OSImages: []*v1.OsImage{
+						{
+							ManualPartition: true,
+							Name:            "Usacloud Linux",
+							OsImageId:       "usacloud",
+							RequirePassword: true,
+							SuperuserName:   "root",
+						},
+					},
+					PowerStatus: &v1.ServerPowerStatus{
+						Status: v1.ServerPowerStatusStatusOn,
+					},
+					TrafficGraph: &v1.TrafficGraph{
+						Receive: []v1.TrafficGraphData{
+							{
+								Timestamp: time.Now(),
+								Value:     1,
+							},
+						},
+						Transmit: []v1.TrafficGraphData{
+							{
+								Timestamp: time.Now(),
+								Value:     1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return httptest.NewServer(fakeServer.Handler())
+}


### PR DESCRIPTION
サーバに対するRead/List/Action(OSインストール/電源操作)を提供する。

ポートチャネル/ポートについては別リソース扱い(子パッケージ)として表現する。
RAID状態や電源状態といった別APIで取得するフィールドについてはRead/List時にオプション指定することで一括取得できる形にする。

### 提供している操作一覧

```go
    func (s *Service) Read(req *ReadRequest) (*Server, error)
    func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*Server, error)

    func (s *Service) Find(req *FindRequest) ([]*Server, error)
    func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*Server, error)

    func (s *Service) Install(req *InstallRequest) error
    func (s *Service) InstallWithContext(ctx context.Context, req *InstallRequest) error

    func (s *Service) Power(req *PowerRequest) error
    func (s *Service) PowerWithContext(ctx context.Context, req *PowerRequest) error
```

### Read/Listで別APIで取得するフィールドの扱い

```go
// Readパラメータ
type ReadRequest struct {
	Id string `service:"-" validate:"required"`

	IncludeFields *IncludeFields
}

// 付加的情報の取得範囲
type IncludeFields struct {
	// RAID状態(キャッシュ)を含むか
	//
	// RefreshedRaidStatusがtrueの場合はそちらが優先される
	CachedRaidStatus bool
	// RAID状態(最新)を含むか
	RefreshedRaidStatus bool

	// 電源状態を含むか
	PowerStatus bool
	// インストール可能OS一覧情報を含むか
	OSImages bool
}

// Read/Listで返される値
type Server struct {
	v1.Server
	*v1.RaidStatus
	*v1.ServerPowerStatus
	OSImages []*v1.OsImage
}
```