### PR TITLE
service: port-channel

### DIFF
--- a/server/port-channel/configure_request.go
+++ b/server/port-channel/configure_request.go
@@ -1,0 +1,50 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portchannel
+
+import (
+	"github.com/sacloud/packages-go/validate"
+	v1 "github.com/sacloud/phy-api-go/apis/v1"
+)
+
+type ConfigureRequest struct {
+	Id       int    `service:"-" validate:"required"`
+	ServerId string `service:"-" validate:"required"`
+
+	// ボンディング方式指定
+	//
+	// * lacp - LACP
+	// * static - static link aggregation
+	// * single - ボンディングなし(単体構成)
+	BondingType string `validate:"required,oneof=lacp static single"`
+
+	// 作成するポート名称の指定
+	//
+	// * nil: 自動設定
+	// * 1要素: ボンディング構成
+	// * 2要素: ボンディングなし
+	PortNicknames *[]string `validate:"omitempty,min=1,max=2,dive,required"`
+}
+
+func (req *ConfigureRequest) Validate() error {
+	return validate.New().Struct(req)
+}
+
+func (req *ConfigureRequest) ToRequestParameter() v1.ConfigureBondingParameter {
+	return v1.ConfigureBondingParameter{
+		BondingType:   v1.BondingType(req.BondingType),
+		PortNicknames: req.PortNicknames,
+	}
+}

--- a/server/port-channel/configure_service.go
+++ b/server/port-channel/configure_service.go
@@ -1,0 +1,40 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portchannel
+
+import (
+	"context"
+
+	"github.com/sacloud/phy-api-go"
+	v1 "github.com/sacloud/phy-api-go/apis/v1"
+)
+
+// Configure ポートチャネル ボンディング設定
+//
+// 既存の設定が存在する場合に実行すると上書き動作(初期化)となる
+func (s *Service) Configure(req *ConfigureRequest) (*v1.PortChannel, error) {
+	return s.ConfigureWithContext(context.Background(), req)
+}
+
+// ConfigureWithContext ポートチャネル ボンディング設定
+//
+// 既存の設定が存在する場合に実行すると上書き動作(初期化)となる
+func (s *Service) ConfigureWithContext(ctx context.Context, req *ConfigureRequest) (*v1.PortChannel, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	client := phy.NewServerOp(s.client)
+	return client.ConfigureBonding(ctx, v1.ServerId(req.ServerId), v1.PortChannelId(req.Id), req.ToRequestParameter())
+}

--- a/server/port-channel/read_request.go
+++ b/server/port-channel/read_request.go
@@ -1,0 +1,28 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portchannel
+
+import (
+	"github.com/sacloud/packages-go/validate"
+)
+
+type ReadRequest struct {
+	Id       int    `service:"-" validate:"required"`
+	ServerId string `service:"-" validate:"required"`
+}
+
+func (req *ReadRequest) Validate() error {
+	return validate.New().Struct(req)
+}

--- a/server/port-channel/read_service.go
+++ b/server/port-channel/read_service.go
@@ -1,0 +1,34 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portchannel
+
+import (
+	"context"
+
+	"github.com/sacloud/phy-api-go"
+	v1 "github.com/sacloud/phy-api-go/apis/v1"
+)
+
+func (s *Service) Read(req *ReadRequest) (*v1.PortChannel, error) {
+	return s.ReadWithContext(context.Background(), req)
+}
+
+func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*v1.PortChannel, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	client := phy.NewServerOp(s.client)
+	return client.ReadPortChannel(ctx, v1.ServerId(req.ServerId), v1.PortChannelId(req.Id))
+}

--- a/server/port-channel/service.go
+++ b/server/port-channel/service.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portchannel
+
+import "github.com/sacloud/phy-api-go"
+
+// Service provides a high-level API of for Service
+type Service struct {
+	client *phy.Client
+}
+
+// New returns new service instance of Service
+func New(client *phy.Client) *Service {
+	return &Service{client: client}
+}


### PR DESCRIPTION
ポートチャネルに対するRead/Configure(Update)操作を提供する。

- Read: 参照
- Configure: ポートチャネルボンディング設定。実行すると配下の {port_id} が新たに採番され 論理ポート情報がリセットされる

Note: コンパネのポートチャネル設定ウィザード相当の機能を提供するか検討したが、パラメータ指定が複雑でうまくまとめられなかった。このためここでは`POST /servers/{server_id}/port_channels/{port_channel_id}/configure_bonding/`を呼ぶだけとし、`POST /servers/{server_id}/ports/{port_id}/assign_network/`は呼び出し側で実行してもらう形とした。

portサービスを実装する中で再考する。