### PR TITLE
service: port-channel.configure

### DIFF
--- a/server/port-channel/configured_port_channel.go
+++ b/server/port-channel/configured_port_channel.go
@@ -1,0 +1,22 @@
+// Copyright 2022 The sacloud/phy-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portchannel
+
+import v1 "github.com/sacloud/phy-api-go/apis/v1"
+
+type ConfiguredPortChannel struct {
+	v1.PortChannel
+	ConfiguredPorts []*v1.InterfacePort
+}

--- a/server/port-channel/service_test.go
+++ b/server/port-channel/service_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sacloud/phy-api-go/fake"
 	"github.com/sacloud/phy-api-go/fake/server"
 	service "github.com/sacloud/phy-service-go"
+	serverService "github.com/sacloud/phy-service-go/server"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,11 +70,21 @@ func TestServerPortChannel_CRUD_plus_L(t *testing.T) {
 			Id:          portChannelId,
 			ServerId:    serverId,
 			BondingType: "lacp",
+			PortSettings: []*PortSetting{
+				{
+					Nickname: "bond01",
+					Network: serverService.NetworkSetting{
+						Mode:         "access",
+						InternetType: "common_subnet",
+					},
+				},
+			},
 		})
 
 		require.NoError(t, err)
 		require.NotEqualValues(t, portChannel.Ports, updated.Ports)
 		require.Equal(t, v1.BondingType("lacp"), updated.BondingType)
+		require.NotEmpty(t, updated.ConfiguredPorts)
 	})
 }
 


### PR DESCRIPTION
closes #7 

Configureで以下のようなパラメータを受け取り、ポートチャネル設定ウィザード相当機能を実装する。

```go
type ConfigureRequest struct {
	Id       int    `service:"-" validate:"required"`
	ServerId string `service:"-" validate:"required"`

	// ボンディング方式指定
	//
	// * lacp - LACP
	// * static - static link aggregation
	// * single - ボンディングなし(単体構成)
	BondingType string `validate:"required,oneof=lacp static single"`

	// ポート設定
	PortSettings []*PortSetting `validate:"required,min=1,max=2,dive"`
}

type PortSetting struct {
	// ポート名
	Nickname string `validate:"required,max=50"`
	// 接続するネットワークの設定
	Network server.NetworkSetting
}
```