### PR TITLE
バージョン定義からプレフィックスを除去

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,7 +24,7 @@ import (
 
 // UserAgent APIリクエスト時のユーザーエージェント
 var UserAgent = fmt.Sprintf(
-	"phy-service-go/%s (%s/%s; +https://github.com/sacloud/phy-service-go) %s",
+	"phy-service-go/v%s (%s/%s; +https://github.com/sacloud/phy-service-go) %s",
 	Version,
 	runtime.GOOS,
 	runtime.GOARCH,

--- a/version.go
+++ b/version.go
@@ -15,4 +15,4 @@
 package service
 
 // Version バージョン
-const Version = "v0.0.1"
+const Version = "0.0.1"


### PR DESCRIPTION
定義ではvプレフィックスをつけず、利用する側で必要に応じて付与する形とする