### PR TITLE
sacloud/services@v0.0.1への準拠

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ bin/
 dist/
 vendor/
 work/
+
+tools/print-service-meta/*.yaml

--- a/Makefile
+++ b/Makefile
@@ -82,3 +82,7 @@ set-license:
 .PHONY: go-licenses-check
 go-licenses-check:
 	go-licenses check .
+
+.PHYNY: services-yaml
+services-yaml:
+	go run tools/print-service-meta/main.go

--- a/dedicated-subnet/find_request.go
+++ b/dedicated-subnet/find_request.go
@@ -15,7 +15,6 @@
 package dedicatedsubnet
 
 import (
-	"github.com/sacloud/packages-go/validate"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
 )
 
@@ -44,11 +43,7 @@ type FindRequest struct {
 	//
 	// * `activated` - 利用開始日順
 	// * `nickname` - 名称順
-	Ordering string `validate:"omitempty,oneof=activated -activated nickname -nickname"`
-}
-
-func (req *FindRequest) Validate() error {
-	return validate.New().Struct(req)
+	Ordering string `validate:"omitempty,ordering" meta:",options=ordering"`
 }
 
 func (req *FindRequest) ToRequestParameter() *v1.ListDedicatedSubnetsParams {

--- a/dedicated-subnet/find_service.go
+++ b/dedicated-subnet/find_service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sacloud/phy-api-go"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/helper"
 )
 
 func (s *Service) Find(req *FindRequest) ([]*v1.DedicatedSubnet, error) {
@@ -29,7 +30,7 @@ func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*v1.
 	if req == nil {
 		req = &FindRequest{}
 	}
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return nil, err
 	}
 

--- a/dedicated-subnet/read_request.go
+++ b/dedicated-subnet/read_request.go
@@ -14,16 +14,8 @@
 
 package dedicatedsubnet
 
-import (
-	"github.com/sacloud/packages-go/validate"
-)
-
 type ReadRequest struct {
 	Id string `service:"-" validate:"required"`
 	// IPv6有効状態の最新状態を取得する(デフォルト:true)
 	Refresh *bool
-}
-
-func (req *ReadRequest) Validate() error {
-	return validate.New().Struct(req)
 }

--- a/dedicated-subnet/read_service.go
+++ b/dedicated-subnet/read_service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sacloud/phy-api-go"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/helper"
 )
 
 func (s *Service) Read(req *ReadRequest) (*v1.DedicatedSubnet, error) {
@@ -26,7 +27,7 @@ func (s *Service) Read(req *ReadRequest) (*v1.DedicatedSubnet, error) {
 }
 
 func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*v1.DedicatedSubnet, error) {
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return nil, err
 	}
 	client := phy.NewDedicatedSubnetOp(s.client)

--- a/dedicated-subnet/service.go
+++ b/dedicated-subnet/service.go
@@ -14,11 +14,41 @@
 
 package dedicatedsubnet
 
-import "github.com/sacloud/phy-api-go"
+import (
+	"github.com/sacloud/phy-api-go"
+	"github.com/sacloud/services"
+	"github.com/sacloud/services/meta"
+)
+
+var _ services.Service = (*Service)(nil)
 
 // Service provides a high-level API of for Service
 type Service struct {
 	client *phy.Client
+}
+
+func (s *Service) Info() *services.Info {
+	return &services.Info{
+		Name: "dedicated-subnet",
+	}
+}
+
+func (s *Service) Operations() []services.SupportedOperation {
+	return []services.SupportedOperation{
+		{Name: "Find", OperationType: services.OperationsList},
+		{Name: "Read", OperationType: services.OperationsRead},
+	}
+}
+
+func (s *Service) Config() *services.Config {
+	return &services.Config{
+		OptionDefs: []*meta.Option{
+			{
+				Key:    "ordering",
+				Values: []string{"activated", "-activated", "nickname", "-nickname"},
+			},
+		},
+	}
 }
 
 // New returns new service instance of Service

--- a/dedicated-subnet/service_test.go
+++ b/dedicated-subnet/service_test.go
@@ -24,7 +24,6 @@ import (
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
 	"github.com/sacloud/phy-api-go/fake"
 	"github.com/sacloud/phy-api-go/fake/server"
-	service "github.com/sacloud/phy-service-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +34,7 @@ func TestAccount_CRUD_plus_L(t *testing.T) {
 	apiClient := &phy.Client{
 		APIRootURL: fakeServer.URL,
 		Options: &client.Options{
-			UserAgent: service.UserAgent,
+			UserAgent: "phy-service-go/test",
 		},
 	}
 	svc := New(apiClient)

--- a/private-network/find_request.go
+++ b/private-network/find_request.go
@@ -15,7 +15,6 @@
 package privatenetwork
 
 import (
-	"github.com/sacloud/packages-go/validate"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
 )
 
@@ -44,11 +43,7 @@ type FindRequest struct {
 	//
 	// * `activated` - 利用開始日順
 	// * `nickname` - 名称順
-	Ordering string `validate:"omitempty,oneof=activated -activated nickname -nickname"`
-}
-
-func (req *FindRequest) Validate() error {
-	return validate.New().Struct(req)
+	Ordering string `validate:"omitempty,ordering"`
 }
 
 func (req *FindRequest) ToRequestParameter() *v1.ListPrivateNetworksParams {

--- a/private-network/find_service.go
+++ b/private-network/find_service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sacloud/phy-api-go"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/helper"
 )
 
 func (s *Service) Find(req *FindRequest) ([]*v1.PrivateNetwork, error) {
@@ -29,7 +30,7 @@ func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*v1.
 	if req == nil {
 		req = &FindRequest{}
 	}
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return nil, err
 	}
 

--- a/private-network/read_request.go
+++ b/private-network/read_request.go
@@ -14,14 +14,6 @@
 
 package privatenetwork
 
-import (
-	"github.com/sacloud/packages-go/validate"
-)
-
 type ReadRequest struct {
 	Id string `service:"-" validate:"required"`
-}
-
-func (req *ReadRequest) Validate() error {
-	return validate.New().Struct(req)
 }

--- a/private-network/read_service.go
+++ b/private-network/read_service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sacloud/phy-api-go"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/helper"
 )
 
 func (s *Service) Read(req *ReadRequest) (*v1.PrivateNetwork, error) {
@@ -26,7 +27,7 @@ func (s *Service) Read(req *ReadRequest) (*v1.PrivateNetwork, error) {
 }
 
 func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*v1.PrivateNetwork, error) {
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return nil, err
 	}
 	client := phy.NewPrivateNetworkOp(s.client)

--- a/private-network/service.go
+++ b/private-network/service.go
@@ -14,11 +14,41 @@
 
 package privatenetwork
 
-import "github.com/sacloud/phy-api-go"
+import (
+	"github.com/sacloud/phy-api-go"
+	"github.com/sacloud/services"
+	"github.com/sacloud/services/meta"
+)
+
+var _ services.Service = (*Service)(nil)
 
 // Service provides a high-level API of for Service
 type Service struct {
 	client *phy.Client
+}
+
+func (s *Service) Info() *services.Info {
+	return &services.Info{
+		Name: "private-network",
+	}
+}
+
+func (s *Service) Operations() []services.SupportedOperation {
+	return []services.SupportedOperation{
+		{Name: "Find", OperationType: services.OperationsList},
+		{Name: "Read", OperationType: services.OperationsRead},
+	}
+}
+
+func (s *Service) Config() *services.Config {
+	return &services.Config{
+		OptionDefs: []*meta.Option{
+			{
+				Key:    "ordering",
+				Values: []string{"activated", "-activated", "nickname", "-nickname"},
+			},
+		},
+	}
 }
 
 // New returns new service instance of Service

--- a/private-network/service_test.go
+++ b/private-network/service_test.go
@@ -24,7 +24,6 @@ import (
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
 	"github.com/sacloud/phy-api-go/fake"
 	"github.com/sacloud/phy-api-go/fake/server"
-	service "github.com/sacloud/phy-service-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +34,7 @@ func TestAccount_CRUD_plus_L(t *testing.T) {
 	apiClient := &phy.Client{
 		APIRootURL: fakeServer.URL,
 		Options: &client.Options{
-			UserAgent: service.UserAgent,
+			UserAgent: "phy-service-go/test",
 		},
 	}
 	svc := New(apiClient)

--- a/server/find_request.go
+++ b/server/find_request.go
@@ -15,14 +15,13 @@
 package server
 
 import (
-	"github.com/sacloud/packages-go/validate"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
 )
 
 type FindRequest struct {
 	// 電源状態
 	// キャッシュされた電源状態で絞りこむ
-	PowerStatus string `validate:"omitempty,oneof=on off"`
+	PowerStatus string `validate:"omitempty,power_status" meta:",options=power_status"`
 
 	// インターネット接続状態の絞り込み
 	//
@@ -62,14 +61,10 @@ type FindRequest struct {
 	//
 	// * `activated` - 利用開始日順
 	// * `nickname` - 名称順
-	Ordering string `validate:"omitempty,oneof=activated -activated nickname -nickname power_status_stored -power_status_stored"`
+	Ordering string `validate:"omitempty,ordering" meta:",options=ordering"`
 
 	// 付加的情報の取得範囲
-	IncludeFields *IncludeFields
-}
-
-func (req *FindRequest) Validate() error {
-	return validate.New().Struct(req)
+	IncludeFields IncludeFields `meta:"include"`
 }
 
 func (req *FindRequest) ToRequestParameter() *v1.ListServersParams {

--- a/server/find_service.go
+++ b/server/find_service.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/sacloud/phy-api-go"
+	"github.com/sacloud/services/helper"
 )
 
 func (s *Service) Find(req *FindRequest) ([]*Server, error) {
@@ -28,7 +29,7 @@ func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*Ser
 	if req == nil {
 		req = &FindRequest{}
 	}
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return nil, err
 	}
 

--- a/server/install_request.go
+++ b/server/install_request.go
@@ -15,7 +15,6 @@
 package server
 
 import (
-	"github.com/sacloud/packages-go/validate"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
 )
 
@@ -36,10 +35,6 @@ type InstallRequest struct {
 	//
 	// リモートコンソールを利用し手動パーティション指定を行うか(OSが対応している場合のみ)
 	ManualPartition bool
-}
-
-func (req *InstallRequest) Validate() error {
-	return validate.New().Struct(req)
 }
 
 func (req *InstallRequest) ToRequestParameter() v1.OsInstallParameter {

--- a/server/install_service.go
+++ b/server/install_service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sacloud/phy-api-go"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/helper"
 )
 
 func (s *Service) Install(req *InstallRequest) error {
@@ -26,7 +27,7 @@ func (s *Service) Install(req *InstallRequest) error {
 }
 
 func (s *Service) InstallWithContext(ctx context.Context, req *InstallRequest) error {
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return err
 	}
 	client := phy.NewServerOp(s.client)

--- a/server/port-channel/configure_request.go
+++ b/server/port-channel/configure_request.go
@@ -15,7 +15,6 @@
 package portchannel
 
 import (
-	"github.com/sacloud/packages-go/validate"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
 	"github.com/sacloud/phy-service-go/server"
 )
@@ -29,7 +28,7 @@ type ConfigureRequest struct {
 	// * lacp - LACP
 	// * static - static link aggregation
 	// * single - ボンディングなし(単体構成)
-	BondingType string `validate:"required,oneof=lacp static single"`
+	BondingType string `validate:"required,bonding_type" meta:",options=bonding_type"`
 
 	// ポート設定
 	PortSettings []*PortSetting `validate:"required,min=1,max=2,dive"`
@@ -40,10 +39,6 @@ type PortSetting struct {
 	Nickname string `validate:"required,max=50"`
 	// 接続するネットワークの設定
 	Network server.NetworkSetting
-}
-
-func (req *ConfigureRequest) Validate() error {
-	return validate.New().Struct(req)
 }
 
 func (req *ConfigureRequest) ConfigureBondingParameter() v1.ConfigureBondingParameter {

--- a/server/port-channel/configure_service.go
+++ b/server/port-channel/configure_service.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sacloud/phy-api-go"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/helper"
 )
 
 // Configure ポートチャネル ボンディング設定
@@ -33,7 +34,7 @@ func (s *Service) Configure(req *ConfigureRequest) (*ConfiguredPortChannel, erro
 //
 // 既存の設定が存在する場合に実行すると上書き動作(初期化)となる
 func (s *Service) ConfigureWithContext(ctx context.Context, req *ConfigureRequest) (*ConfiguredPortChannel, error) {
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return nil, err
 	}
 	client := phy.NewServerOp(s.client)

--- a/server/port-channel/read_request.go
+++ b/server/port-channel/read_request.go
@@ -14,15 +14,7 @@
 
 package portchannel
 
-import (
-	"github.com/sacloud/packages-go/validate"
-)
-
 type ReadRequest struct {
 	Id       int    `service:"-" validate:"required"`
 	ServerId string `service:"-" validate:"required"`
-}
-
-func (req *ReadRequest) Validate() error {
-	return validate.New().Struct(req)
 }

--- a/server/port-channel/read_service.go
+++ b/server/port-channel/read_service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sacloud/phy-api-go"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/helper"
 )
 
 func (s *Service) Read(req *ReadRequest) (*v1.PortChannel, error) {
@@ -26,7 +27,7 @@ func (s *Service) Read(req *ReadRequest) (*v1.PortChannel, error) {
 }
 
 func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*v1.PortChannel, error) {
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return nil, err
 	}
 	client := phy.NewServerOp(s.client)

--- a/server/port-channel/service.go
+++ b/server/port-channel/service.go
@@ -14,11 +14,45 @@
 
 package portchannel
 
-import "github.com/sacloud/phy-api-go"
+import (
+	"github.com/sacloud/phy-api-go"
+	"github.com/sacloud/phy-service-go/server"
+	"github.com/sacloud/services"
+	"github.com/sacloud/services/meta"
+)
+
+var _ services.Service = (*Service)(nil)
 
 // Service provides a high-level API of for Service
 type Service struct {
 	client *phy.Client
+}
+
+func (s *Service) Info() *services.Info {
+	return &services.Info{
+		Name:       "port-channel",
+		ParentKeys: []string{"ServerId"},
+	}
+}
+
+func (s *Service) Operations() []services.SupportedOperation {
+	return []services.SupportedOperation{
+		{Name: "Read", OperationType: services.OperationsRead},
+		{Name: "Configure", OperationType: services.OperationsUpdate},
+	}
+}
+
+func (s *Service) Config() *services.Config {
+	config := &services.Config{
+		OptionDefs: []*meta.Option{
+			{
+				Key:    "bonding_type",
+				Values: []string{"lacp", "static", "single"},
+			},
+		},
+	}
+	config.OptionDefs = append(config.OptionDefs, server.NetworkSettingOptions...)
+	return config
 }
 
 // New returns new service instance of Service

--- a/server/port-channel/service_test.go
+++ b/server/port-channel/service_test.go
@@ -24,7 +24,6 @@ import (
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
 	"github.com/sacloud/phy-api-go/fake"
 	"github.com/sacloud/phy-api-go/fake/server"
-	service "github.com/sacloud/phy-service-go"
 	serverService "github.com/sacloud/phy-service-go/server"
 	"github.com/stretchr/testify/require"
 )
@@ -37,7 +36,7 @@ func TestServerPortChannel_CRUD_plus_L(t *testing.T) {
 	apiClient := &phy.Client{
 		APIRootURL: fakeServer.URL,
 		Options: &client.Options{
-			UserAgent: service.UserAgent,
+			UserAgent: "phy-service-go/test",
 		},
 	}
 	svc := New(apiClient)

--- a/server/port/find_request.go
+++ b/server/port/find_request.go
@@ -14,14 +14,6 @@
 
 package port
 
-import (
-	"github.com/sacloud/packages-go/validate"
-)
-
 type FindRequest struct {
 	ServerId string `service:"-" validate:"required"`
-}
-
-func (req *FindRequest) Validate() error {
-	return validate.New().Struct(req)
 }

--- a/server/port/find_service.go
+++ b/server/port/find_service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sacloud/phy-api-go"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/helper"
 )
 
 func (s *Service) Find(req *FindRequest) ([]*v1.InterfacePort, error) {
@@ -26,7 +27,7 @@ func (s *Service) Find(req *FindRequest) ([]*v1.InterfacePort, error) {
 }
 
 func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*v1.InterfacePort, error) {
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return nil, err
 	}
 	client := phy.NewServerOp(s.client)

--- a/server/port/read_request.go
+++ b/server/port/read_request.go
@@ -14,15 +14,7 @@
 
 package port
 
-import (
-	"github.com/sacloud/packages-go/validate"
-)
-
 type ReadRequest struct {
 	Id       int    `service:"-" validate:"required"`
 	ServerId string `service:"-" validate:"required"`
-}
-
-func (req *ReadRequest) Validate() error {
-	return validate.New().Struct(req)
 }

--- a/server/port/read_service.go
+++ b/server/port/read_service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sacloud/phy-api-go"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/helper"
 )
 
 func (s *Service) Read(req *ReadRequest) (*v1.InterfacePort, error) {
@@ -26,7 +27,7 @@ func (s *Service) Read(req *ReadRequest) (*v1.InterfacePort, error) {
 }
 
 func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*v1.InterfacePort, error) {
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return nil, err
 	}
 	client := phy.NewServerOp(s.client)

--- a/server/port/service.go
+++ b/server/port/service.go
@@ -14,11 +14,47 @@
 
 package port
 
-import "github.com/sacloud/phy-api-go"
+import (
+	"github.com/sacloud/phy-api-go"
+	"github.com/sacloud/phy-service-go/server"
+	"github.com/sacloud/services"
+	"github.com/sacloud/services/meta"
+)
+
+var _ services.Service = (*Service)(nil)
 
 // Service provides a high-level API of for Service
 type Service struct {
 	client *phy.Client
+}
+
+func (s *Service) Info() *services.Info {
+	return &services.Info{
+		Name:       "port",
+		ParentKeys: []string{"ServerId"},
+	}
+}
+
+func (s *Service) Operations() []services.SupportedOperation {
+	return []services.SupportedOperation{
+		{Name: "Find", OperationType: services.OperationsList},
+		{Name: "Read", OperationType: services.OperationsRead},
+		{Name: "TrafficGraph", OperationType: services.OperationsRead},
+		{Name: "Update", OperationType: services.OperationsUpdate},
+	}
+}
+
+func (s *Service) Config() *services.Config {
+	config := &services.Config{
+		OptionDefs: []*meta.Option{
+			{
+				Key:    "step",
+				Values: []string{"300", "600", "3600", "21600"},
+			},
+		},
+	}
+	config.OptionDefs = append(config.OptionDefs, server.NetworkSettingOptions...)
+	return config
 }
 
 // New returns new service instance of Service

--- a/server/port/service_test.go
+++ b/server/port/service_test.go
@@ -25,7 +25,6 @@ import (
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
 	"github.com/sacloud/phy-api-go/fake"
 	"github.com/sacloud/phy-api-go/fake/server"
-	service "github.com/sacloud/phy-service-go"
 	serverService "github.com/sacloud/phy-service-go/server"
 	"github.com/stretchr/testify/require"
 )
@@ -39,7 +38,7 @@ func TestServerPort_CRUD_plus_L(t *testing.T) {
 	apiClient := &phy.Client{
 		APIRootURL: fakeServer.URL,
 		Options: &client.Options{
-			UserAgent: service.UserAgent,
+			UserAgent: "phy-service-go/test",
 		},
 	}
 	svc := New(apiClient)

--- a/server/port/traffic_graph_request.go
+++ b/server/port/traffic_graph_request.go
@@ -17,7 +17,6 @@ package port
 import (
 	"time"
 
-	"github.com/sacloud/packages-go/validate"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
 )
 
@@ -30,11 +29,7 @@ type TrafficGraphRequest struct {
 	// 取得範囲終点(未指定時は現在時刻)
 	Until time.Time `validate:"omitempty"`
 	// データポイント間隔(秒)
-	Step int `validate:"omitempty,oneof=300 600 3600 21600"`
-}
-
-func (req *TrafficGraphRequest) Validate() error {
-	return validate.New().Struct(req)
+	Step int `validate:"omitempty,step" meta:",options=step"`
 }
 
 func (req *TrafficGraphRequest) ToRequestParameter() v1.ReadServerTrafficByPortParams {

--- a/server/port/traffic_graph_service.go
+++ b/server/port/traffic_graph_service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sacloud/phy-api-go"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/helper"
 )
 
 func (s *Service) TrafficGraph(req *TrafficGraphRequest) (*v1.TrafficGraph, error) {
@@ -26,7 +27,7 @@ func (s *Service) TrafficGraph(req *TrafficGraphRequest) (*v1.TrafficGraph, erro
 }
 
 func (s *Service) TrafficGraphWithContext(ctx context.Context, req *TrafficGraphRequest) (*v1.TrafficGraph, error) {
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return nil, err
 	}
 	client := phy.NewServerOp(s.client)

--- a/server/port/update_request.go
+++ b/server/port/update_request.go
@@ -15,7 +15,6 @@
 package port
 
 import (
-	"github.com/sacloud/packages-go/validate"
 	"github.com/sacloud/phy-service-go/server"
 )
 
@@ -29,8 +28,4 @@ type UpdateRequest struct {
 	Enabled *bool `validate:"omitempty"`
 	// ネットワーク接続設定
 	Network *server.NetworkSetting `validate:"omitempty"`
-}
-
-func (req *UpdateRequest) Validate() error {
-	return validate.New().Struct(req)
 }

--- a/server/port/update_service.go
+++ b/server/port/update_service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sacloud/phy-api-go"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/helper"
 )
 
 func (s *Service) Update(req *UpdateRequest) (*v1.InterfacePort, error) {
@@ -26,7 +27,7 @@ func (s *Service) Update(req *UpdateRequest) (*v1.InterfacePort, error) {
 }
 
 func (s *Service) UpdateWithContext(ctx context.Context, req *UpdateRequest) (*v1.InterfacePort, error) {
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return nil, err
 	}
 	client := phy.NewServerOp(s.client)

--- a/server/power_request.go
+++ b/server/power_request.go
@@ -16,15 +16,13 @@ package server
 
 import (
 	"time"
-
-	"github.com/sacloud/packages-go/validate"
 )
 
 type PowerRequest struct {
 	Id string `service:"-" validate:"required"`
 
 	// 電源操作内容
-	Operation string `validate:"required,oneof=on soft reset off"`
+	Operation string `validate:"required,power_operation" meta:",options=power_operation"`
 
 	// 電源操作後に希望の状態になるまで待つか
 	NoWait bool
@@ -34,8 +32,4 @@ type PowerRequest struct {
 
 	// 待ち処理の処理間隔
 	Interval time.Duration `validate:"omitempty,min=0"`
-}
-
-func (req *PowerRequest) Validate() error {
-	return validate.New().Struct(req)
 }

--- a/server/power_service.go
+++ b/server/power_service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sacloud/packages-go/wait"
 	"github.com/sacloud/phy-api-go"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/helper"
 )
 
 func (s *Service) Power(req *PowerRequest) error {
@@ -28,7 +29,7 @@ func (s *Service) Power(req *PowerRequest) error {
 }
 
 func (s *Service) PowerWithContext(ctx context.Context, req *PowerRequest) error {
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return err
 	}
 	client := phy.NewServerOp(s.client)

--- a/server/power_service_test.go
+++ b/server/power_service_test.go
@@ -20,7 +20,6 @@ import (
 
 	client "github.com/sacloud/api-client-go"
 	"github.com/sacloud/phy-api-go"
-	service "github.com/sacloud/phy-service-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,7 +28,7 @@ func TestService_Power(t *testing.T) {
 	apiClient := &phy.Client{
 		APIRootURL: fakeServer.URL,
 		Options: &client.Options{
-			UserAgent: service.UserAgent,
+			UserAgent: "phy-service-go/test",
 		},
 	}
 	svc := New(apiClient)

--- a/server/read_request.go
+++ b/server/read_request.go
@@ -14,17 +14,9 @@
 
 package server
 
-import (
-	"github.com/sacloud/packages-go/validate"
-)
-
 type ReadRequest struct {
 	Id string `service:"-" validate:"required"`
 
 	// 付加的情報の取得範囲
-	IncludeFields *IncludeFields
-}
-
-func (req *ReadRequest) Validate() error {
-	return validate.New().Struct(req)
+	IncludeFields IncludeFields
 }

--- a/server/read_service.go
+++ b/server/read_service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sacloud/phy-api-go"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/helper"
 )
 
 func (s *Service) Read(req *ReadRequest) (*Server, error) {
@@ -26,7 +27,7 @@ func (s *Service) Read(req *ReadRequest) (*Server, error) {
 }
 
 func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*Server, error) {
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return nil, err
 	}
 	client := phy.NewServerOp(s.client)

--- a/server/server.go
+++ b/server/server.go
@@ -42,11 +42,7 @@ type IncludeFields struct {
 	OSImages bool
 }
 
-func (s *Service) fetchAdditionalInfo(ctx context.Context, server *Server, fields *IncludeFields) error {
-	if fields == nil {
-		return nil
-	}
-
+func (s *Service) fetchAdditionalInfo(ctx context.Context, server *Server, fields IncludeFields) error {
 	client := phy.NewServerOp(s.client)
 	if fields.CachedRaidStatus || fields.RefreshedRaidStatus {
 		status, err := client.ReadRAIDStatus(ctx, v1.ServerId(server.ServerId), fields.RefreshedRaidStatus)

--- a/server/service.go
+++ b/server/service.go
@@ -14,11 +14,53 @@
 
 package server
 
-import "github.com/sacloud/phy-api-go"
+import (
+	"github.com/sacloud/phy-api-go"
+	"github.com/sacloud/services"
+	"github.com/sacloud/services/meta"
+)
+
+var _ services.Service = (*Service)(nil)
 
 // Service provides a high-level API of for Service
 type Service struct {
 	client *phy.Client
+}
+
+func (s *Service) Info() *services.Info {
+	return &services.Info{
+		Name: "server",
+	}
+}
+
+func (s *Service) Operations() []services.SupportedOperation {
+	return []services.SupportedOperation{
+		{Name: "Find", OperationType: services.OperationsList},
+		{Name: "Install", OperationType: services.OperationsAction},
+		{Name: "Power", OperationType: services.OperationsAction},
+		{Name: "Read", OperationType: services.OperationsRead},
+	}
+}
+
+func (s *Service) Config() *services.Config {
+	config := &services.Config{
+		OptionDefs: []*meta.Option{
+			{
+				Key:    "ordering",
+				Values: []string{"activated", "-activated", "nickname", "-nickname", "power_status_stored", "-power_status_stored"},
+			},
+			{
+				Key:    "power_status",
+				Values: []string{"on", "off"},
+			},
+			{
+				Key:    "power_operation",
+				Values: []string{"on", "soft", "reset", "off"},
+			},
+		},
+	}
+	config.OptionDefs = append(config.OptionDefs, NetworkSettingOptions...)
+	return config
 }
 
 // New returns new service instance of Service

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -24,7 +24,6 @@ import (
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
 	"github.com/sacloud/phy-api-go/fake"
 	"github.com/sacloud/phy-api-go/fake/server"
-	service "github.com/sacloud/phy-service-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +34,7 @@ func TestServer_CRUD_plus_L(t *testing.T) {
 	apiClient := &phy.Client{
 		APIRootURL: fakeServer.URL,
 		Options: &client.Options{
-			UserAgent: service.UserAgent,
+			UserAgent: "phy-service-go/test",
 		},
 	}
 	svc := New(apiClient)
@@ -59,7 +58,7 @@ func TestServer_CRUD_plus_L(t *testing.T) {
 	t.Run("read with additional fields", func(t *testing.T) {
 		read, err := svc.Read(&ReadRequest{
 			Id: serverId,
-			IncludeFields: &IncludeFields{
+			IncludeFields: IncludeFields{
 				CachedRaidStatus:    true,
 				RefreshedRaidStatus: true,
 				PowerStatus:         true,
@@ -99,7 +98,7 @@ func TestServer_CRUD_plus_L(t *testing.T) {
 
 	t.Run("list with additional fields", func(t *testing.T) {
 		found, err := svc.Find(&FindRequest{
-			IncludeFields: &IncludeFields{
+			IncludeFields: IncludeFields{
 				CachedRaidStatus:    true,
 				RefreshedRaidStatus: true,
 				PowerStatus:         true,

--- a/server/types.go
+++ b/server/types.go
@@ -14,20 +14,34 @@
 
 package server
 
-import v1 "github.com/sacloud/phy-api-go/apis/v1"
+import (
+	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/meta"
+)
+
+var NetworkSettingOptions = []*meta.Option{
+	{
+		Key:    "network_mode",
+		Values: []string{"access", "trunk"},
+	},
+	{
+		Key:    "internet_type",
+		Values: []string{"", "common_subnet", "dedicated_subnet"},
+	},
+}
 
 type NetworkSetting struct {
 	// ポートモード
 	//
 	// * access - アクセスポート
 	// * trunk - トランクポート
-	Mode string `validate:"required,oneof=access trunk"`
+	Mode string `validate:"required,network_mode" meta:",options=network_mode"`
 
 	// インターネット接続タイプ
 	// * 空 - インターネット接続なし
 	// * common_subnet - 共用グローバルネットワーク利用
 	// * dedicated_subnet - 専用グローバルネットワーク利用
-	InternetType string `validate:"omitempty,oneof=common_subnet dedicated_subnet"`
+	InternetType string `validate:"omitempty,internet_type" meta:",options=internet_type"`
 
 	// 専用グローバルネットワークのサービスコード
 	//

--- a/service/find_request.go
+++ b/service/find_request.go
@@ -15,7 +15,6 @@
 package service
 
 import (
-	"github.com/sacloud/packages-go/validate"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
 )
 
@@ -27,7 +26,7 @@ type FindRequest struct {
 	// * private_network
 	// * firewall
 	// * load_balancer
-	ProductCategory string `validate:"omitempty,oneof=server dedicated_subnet private_network firewall load_balancer"`
+	ProductCategory string `validate:"omitempty,product_category" meta:",options=product_category"`
 
 	// タグ検索
 	// このクエリーパラメーターを複数指定した場合は **すべてのタグを設定済み(AND)** のものにマッチ
@@ -53,11 +52,7 @@ type FindRequest struct {
 	//
 	// * `activated` - 利用開始日順
 	// * `nickname` - 名称順
-	Ordering string `validate:"omitempty,oneof=activated -activated nickname -nickname"`
-}
-
-func (req *FindRequest) Validate() error {
-	return validate.New().Struct(req)
+	Ordering string `validate:"omitempty,ordering" meta:",options=ordering"`
 }
 
 func (req *FindRequest) ToRequestParameter() *v1.ListServicesParams {

--- a/service/find_service.go
+++ b/service/find_service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sacloud/phy-api-go"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/helper"
 )
 
 func (s *Service) Find(req *FindRequest) ([]*v1.Service, error) {
@@ -29,7 +30,7 @@ func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*v1.
 	if req == nil {
 		req = &FindRequest{}
 	}
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return nil, err
 	}
 

--- a/service/read_request.go
+++ b/service/read_request.go
@@ -14,14 +14,6 @@
 
 package service
 
-import (
-	"github.com/sacloud/packages-go/validate"
-)
-
 type ReadRequest struct {
 	Id string `service:"-" validate:"required"`
-}
-
-func (req *ReadRequest) Validate() error {
-	return validate.New().Struct(req)
 }

--- a/service/read_service.go
+++ b/service/read_service.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sacloud/phy-api-go"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
+	"github.com/sacloud/services/helper"
 )
 
 func (s *Service) Read(req *ReadRequest) (*v1.Service, error) {
@@ -26,7 +27,7 @@ func (s *Service) Read(req *ReadRequest) (*v1.Service, error) {
 }
 
 func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*v1.Service, error) {
-	if err := req.Validate(); err != nil {
+	if err := helper.ValidateStruct(s, req); err != nil {
 		return nil, err
 	}
 	client := phy.NewServiceOp(s.client)

--- a/service/service.go
+++ b/service/service.go
@@ -14,14 +14,49 @@
 
 package service
 
-import "github.com/sacloud/phy-api-go"
+import (
+	"github.com/sacloud/phy-api-go"
+	"github.com/sacloud/services"
+	"github.com/sacloud/services/meta"
+)
 
 // Service provides a high-level API of for Service
 type Service struct {
 	client *phy.Client
 }
 
+var _ services.Service = (*Service)(nil)
+
 // New returns new service instance of Service
 func New(client *phy.Client) *Service {
 	return &Service{client: client}
+}
+
+func (s *Service) Info() *services.Info {
+	return &services.Info{
+		Name: "service",
+	}
+}
+
+func (s *Service) Operations() []services.SupportedOperation {
+	return []services.SupportedOperation{
+		{Name: "Find", OperationType: services.OperationsList},
+		{Name: "Read", OperationType: services.OperationsRead},
+		{Name: "Update", OperationType: services.OperationsUpdate},
+	}
+}
+
+func (s *Service) Config() *services.Config {
+	return &services.Config{
+		OptionDefs: []*meta.Option{
+			{
+				Key:    "product_category",
+				Values: []string{"server", "dedicated_subnet", "private_network", "firewall", "load_balancer"},
+			},
+			{
+				Key:    "ordering",
+				Values: []string{"activated", "-activated", "nickname", "-nickname"},
+			},
+		},
+	}
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -24,7 +24,6 @@ import (
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
 	"github.com/sacloud/phy-api-go/fake"
 	"github.com/sacloud/phy-api-go/fake/server"
-	service "github.com/sacloud/phy-service-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +34,7 @@ func TestAccount_CRUD_plus_L(t *testing.T) {
 	apiClient := &phy.Client{
 		APIRootURL: fakeServer.URL,
 		Options: &client.Options{
-			UserAgent: service.UserAgent,
+			UserAgent: "phy-service-go/test",
 		},
 	}
 	svc := New(apiClient)

--- a/service/update_request.go
+++ b/service/update_request.go
@@ -15,7 +15,6 @@
 package service
 
 import (
-	"github.com/sacloud/packages-go/validate"
 	v1 "github.com/sacloud/phy-api-go/apis/v1"
 )
 
@@ -27,10 +26,6 @@ type UpdateRequest struct {
 
 	// 名称：サーバーやネットワークなどの表示名
 	Nickname *string `json:"nickname" validate:"omitempty"`
-}
-
-func (req *UpdateRequest) Validate() error {
-	return validate.New().Struct(req)
 }
 
 func (req *UpdateRequest) ToRequestParameter(current *v1.Service) v1.UpdateServiceParameter {

--- a/services.go
+++ b/services.go
@@ -15,25 +15,24 @@
 package service
 
 import (
-	"context"
-
 	"github.com/sacloud/phy-api-go"
-	v1 "github.com/sacloud/phy-api-go/apis/v1"
-	"github.com/sacloud/services/helper"
+	dedicatedsubnet "github.com/sacloud/phy-service-go/dedicated-subnet"
+	privatenetwork "github.com/sacloud/phy-service-go/private-network"
+	"github.com/sacloud/phy-service-go/server"
+	"github.com/sacloud/phy-service-go/server/port"
+	portchannel "github.com/sacloud/phy-service-go/server/port-channel"
+	"github.com/sacloud/phy-service-go/service"
+	"github.com/sacloud/services"
 )
 
-func (s *Service) Update(req *UpdateRequest) (*v1.Service, error) {
-	return s.UpdateWithContext(context.Background(), req)
-}
-
-func (s *Service) UpdateWithContext(ctx context.Context, req *UpdateRequest) (*v1.Service, error) {
-	if err := helper.ValidateStruct(s, req); err != nil {
-		return nil, err
+// Services サービス一覧を返す
+func Services(client *phy.Client) []services.Service {
+	return []services.Service{
+		service.New(client),
+		dedicatedsubnet.New(client),
+		privatenetwork.New(client),
+		server.New(client),
+		port.New(client),
+		portchannel.New(client),
 	}
-	client := phy.NewServiceOp(s.client)
-	current, err := client.Read(ctx, v1.ServiceId(req.Id))
-	if err != nil {
-		return nil, err
-	}
-	return client.Update(ctx, v1.ServiceId(req.Id), req.ToRequestParameter(current))
 }

--- a/tools/print-service-meta/go.mod
+++ b/tools/print-service-meta/go.mod
@@ -1,20 +1,17 @@
-module github.com/sacloud/phy-service-go
+module github.com/sacloud/phy-service-go/tools/print-service-meta
 
 go 1.17
 
+replace github.com/sacloud/phy-service-go => ../../
+
 require (
-	github.com/sacloud/api-client-go v0.0.3
-	github.com/sacloud/packages-go v0.0.2
-	github.com/sacloud/phy-api-go v0.0.5
+	github.com/sacloud/phy-service-go v0.0.0-00010101000000-000000000000
 	github.com/sacloud/services v0.0.1
-	github.com/stretchr/testify v1.7.1
 )
 
 require (
 	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deepmap/oapi-codegen v1.9.0 // indirect
-	github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/gin-gonic/gin v1.7.4 // indirect
 	github.com/go-playground/locales v0.14.0 // indirect
@@ -31,8 +28,10 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sacloud/api-client-go v0.0.3 // indirect
 	github.com/sacloud/go-http v0.0.4 // indirect
+	github.com/sacloud/packages-go v0.0.2 // indirect
+	github.com/sacloud/phy-api-go v0.0.5 // indirect
 	github.com/ugorji/go/codec v1.2.6 // indirect
 	go.uber.org/ratelimit v0.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect
@@ -40,5 +39,4 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/tools/print-service-meta/go.sum
+++ b/tools/print-service-meta/go.sum
@@ -291,6 +291,7 @@ github.com/sacloud/packages-go v0.0.2 h1:tvA/V8tjzaCeuQQVwby1Olq6RmjMI/LEdAe65+q
 github.com/sacloud/packages-go v0.0.2/go.mod h1:Eny1qnbKr9n/5yfXDiwOC+0YMiBhK1HBYGjjmxes+CI=
 github.com/sacloud/phy-api-go v0.0.5 h1:AWh7ACVC6Rfx2UFVLU27n2NuQSZM/urb05vUPDKh4Mw=
 github.com/sacloud/phy-api-go v0.0.5/go.mod h1:u+tzv8JurE+6U+q5y0ZYmqsUaVPtauorAeCqp1TtRBg=
+github.com/sacloud/services v0.0.0-20220415043249-e50dd4c6e1b1/go.mod h1:iKmGnTl+oBZzOz44nz5HGsa+xmY1YnIblwijAih6KmQ=
 github.com/sacloud/services v0.0.1 h1:LiPeX+NgdKAkE2/UfInmVJdqKO2V24Q3OHiupsYTGck=
 github.com/sacloud/services v0.0.1/go.mod h1:iKmGnTl+oBZzOz44nz5HGsa+xmY1YnIblwijAih6KmQ=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/tools/print-service-meta/main.go
+++ b/tools/print-service-meta/main.go
@@ -12,29 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package service
+package main
 
 import (
-	"fmt"
-	"runtime"
-
-	client "github.com/sacloud/api-client-go"
-	"github.com/sacloud/phy-api-go"
+	service "github.com/sacloud/phy-service-go"
+	"github.com/sacloud/services/helper"
 )
 
-// UserAgent APIリクエスト時のユーザーエージェント
-var UserAgent = fmt.Sprintf(
-	"phy-service-go/v%s (%s/%s; +https://github.com/sacloud/phy-service-go) %s",
-	Version,
-	runtime.GOOS,
-	runtime.GOARCH,
-	phy.UserAgent,
-)
-
-func NewClient() *phy.Client {
-	return &phy.Client{
-		Options: &client.Options{
-			UserAgent: UserAgent,
-		},
+func main() {
+	for _, s := range service.Services(nil) {
+		helper.PrintServiceMeta(s)
 	}
 }


### PR DESCRIPTION
phy-service-goのすべてのサービスをsacloud/services互換とするために、各サービス/パラメータでservices.Serviceを実装する。

~Note: sacloud/servicesへのフィードバックを目的としているため一旦ペンディング、フィードバック後にマージする。~